### PR TITLE
#26 parameter values were not passed on to worker

### DIFF
--- a/src/main/java/nl/topicus/jdbc/statement/CloudSpannerPreparedStatement.java
+++ b/src/main/java/nl/topicus/jdbc/statement/CloudSpannerPreparedStatement.java
@@ -629,7 +629,8 @@ public class CloudSpannerPreparedStatement extends AbstractCloudSpannerPreparedS
 			mode = DMLOperation.ONDUPLICATEKEYUPDATE;
 		else
 			mode = DMLOperation.INSERT;
-		return new InsertWorker(getConnection(), select, insert, getConnection().isAllowExtendedMode(), mode);
+		return new InsertWorker(getConnection(), select, insert, getParameterStore(),
+				getConnection().isAllowExtendedMode(), mode);
 	}
 
 	private DeleteWorker createDeleteWorker(Delete delete) throws SQLException
@@ -638,7 +639,7 @@ public class CloudSpannerPreparedStatement extends AbstractCloudSpannerPreparedS
 		{
 			throw new CloudSpannerSQLException("DELETE statement must contain only one table", Code.INVALID_ARGUMENT);
 		}
-		return new DeleteWorker(getConnection(), delete, getConnection().isAllowExtendedMode());
+		return new DeleteWorker(getConnection(), delete, getParameterStore(), getConnection().isAllowExtendedMode());
 	}
 
 	boolean isForceUpdate()

--- a/src/main/java/nl/topicus/jdbc/statement/DeleteWorker.java
+++ b/src/main/java/nl/topicus/jdbc/statement/DeleteWorker.java
@@ -20,9 +20,10 @@ public class DeleteWorker extends AbstractTablePartWorker
 {
 	final Delete delete;
 
-	public DeleteWorker(CloudSpannerConnection connection, Delete delete, boolean allowExtendedMode) throws SQLException
+	public DeleteWorker(CloudSpannerConnection connection, Delete delete, ParameterStore parameters,
+			boolean allowExtendedMode) throws SQLException
 	{
-		super(connection, createSelect(connection, delete), allowExtendedMode, DMLOperation.DELETE);
+		super(connection, createSelect(connection, delete), parameters, allowExtendedMode, DMLOperation.DELETE);
 		this.delete = delete;
 	}
 

--- a/src/main/java/nl/topicus/jdbc/statement/InsertWorker.java
+++ b/src/main/java/nl/topicus/jdbc/statement/InsertWorker.java
@@ -15,10 +15,10 @@ public class InsertWorker extends AbstractTablePartWorker
 {
 	final Insert insert;
 
-	public InsertWorker(CloudSpannerConnection connection, Select select, Insert insert, boolean allowExtendedMode,
-			DMLOperation operation)
+	public InsertWorker(CloudSpannerConnection connection, Select select, Insert insert, ParameterStore parameters,
+			boolean allowExtendedMode, DMLOperation operation)
 	{
-		super(connection, select, allowExtendedMode, operation);
+		super(connection, select, parameters, allowExtendedMode, operation);
 		this.insert = insert;
 	}
 


### PR DESCRIPTION
Parameter values of bulk update/delete statements were not passed on to the worker that generated the mutations.