### PR TITLE
Task #31 - Add support for savepoints

### DIFF
--- a/src/main/java/nl/topicus/jdbc/CloudSpannerConnection.java
+++ b/src/main/java/nl/topicus/jdbc/CloudSpannerConnection.java
@@ -780,6 +780,7 @@ public class CloudSpannerConnection extends AbstractCloudSpannerConnection
 	 * @return 1 if the property was set, 0 if not (this complies with the
 	 *         normal behaviour of executeUpdate(...) methods)
 	 * @throws SQLException
+	 *             Throws {@link SQLException} if a database error occurs
 	 */
 	public int setDynamicConnectionProperty(String propertyName, String propertyValue) throws SQLException
 	{
@@ -795,6 +796,7 @@ public class CloudSpannerConnection extends AbstractCloudSpannerConnection
 	 * @return 1 if the property was reset, 0 if not (this complies with the
 	 *         normal behaviour of executeUpdate(...) methods)
 	 * @throws SQLException
+	 *             Throws {@link SQLException} if a database error occurs
 	 */
 	public int resetDynamicConnectionProperty(String propertyName) throws SQLException
 	{

--- a/src/main/java/nl/topicus/jdbc/CloudSpannerConnection.java
+++ b/src/main/java/nl/topicus/jdbc/CloudSpannerConnection.java
@@ -936,6 +936,17 @@ public class CloudSpannerConnection extends AbstractCloudSpannerConnection
 
 	/**
 	 * 
+	 * @return The read timestamp for the current read-only transaction, or null
+	 *         if there is no read-only transaction
+	 */
+	@Override
+	public Timestamp getReadTimestamp()
+	{
+		return transaction == null ? null : transaction.getReadTimestamp();
+	}
+
+	/**
+	 * 
 	 * @return A new connection with the same URL and properties as this
 	 *         connection. You can use this method if you want to open a new
 	 *         connection to the same database, for example to run a number of

--- a/src/main/java/nl/topicus/jdbc/ICloudSpannerConnection.java
+++ b/src/main/java/nl/topicus/jdbc/ICloudSpannerConnection.java
@@ -47,6 +47,8 @@ public interface ICloudSpannerConnection extends Connection
 
 	public Timestamp getLastCommitTimestamp();
 
+	public Timestamp getReadTimestamp();
+
 	public boolean isBatchReadOnly();
 
 	public int setBatchReadOnly(boolean batchReadOnly) throws SQLException;

--- a/src/main/java/nl/topicus/jdbc/transaction/CloudSpannerTransaction.java
+++ b/src/main/java/nl/topicus/jdbc/transaction/CloudSpannerTransaction.java
@@ -37,6 +37,8 @@ import nl.topicus.jdbc.exception.CloudSpannerSQLException;
  */
 public class CloudSpannerTransaction implements TransactionContext, BatchReadOnlyTransaction
 {
+	private static final String SAVEPOINTS_NOT_IN_READ_ONLY = "Savepoints are not allowed in read-only mode";
+
 	public static class TransactionException extends RuntimeException
 	{
 		private static final long serialVersionUID = 1L;
@@ -182,8 +184,7 @@ public class CloudSpannerTransaction implements TransactionContext, BatchReadOnl
 		Preconditions.checkNotNull(savepoint);
 		checkTransaction();
 		if (transactionThread == null)
-			throw new CloudSpannerSQLException("Savepoints are not allowed in read-only mode",
-					Code.FAILED_PRECONDITION);
+			throw new CloudSpannerSQLException(SAVEPOINTS_NOT_IN_READ_ONLY, Code.FAILED_PRECONDITION);
 		transactionThread.setSavepoint(savepoint);
 	}
 
@@ -192,8 +193,7 @@ public class CloudSpannerTransaction implements TransactionContext, BatchReadOnl
 		Preconditions.checkNotNull(savepoint);
 		checkTransaction();
 		if (transactionThread == null)
-			throw new CloudSpannerSQLException("Savepoints are not allowed in read-only mode",
-					Code.FAILED_PRECONDITION);
+			throw new CloudSpannerSQLException(SAVEPOINTS_NOT_IN_READ_ONLY, Code.FAILED_PRECONDITION);
 		transactionThread.rollbackSavepoint(savepoint);
 	}
 
@@ -202,8 +202,7 @@ public class CloudSpannerTransaction implements TransactionContext, BatchReadOnl
 		Preconditions.checkNotNull(savepoint);
 		checkTransaction();
 		if (transactionThread == null)
-			throw new CloudSpannerSQLException("Savepoints are not allowed in read-only mode",
-					Code.FAILED_PRECONDITION);
+			throw new CloudSpannerSQLException(SAVEPOINTS_NOT_IN_READ_ONLY, Code.FAILED_PRECONDITION);
 		transactionThread.releaseSavepoint(savepoint);
 	}
 

--- a/src/test/java/nl/topicus/jdbc/test/integration/CloudSpannerIT.java
+++ b/src/test/java/nl/topicus/jdbc/test/integration/CloudSpannerIT.java
@@ -44,6 +44,8 @@ public class CloudSpannerIT
 {
 	private static final Logger log = Logger.getLogger(CloudSpannerIT.class.getName());
 
+	private static final int ERROR = 1;
+
 	private static final boolean CREATE_INSTANCE = true;
 
 	private static final boolean CREATE_DATABASE = true;
@@ -100,6 +102,10 @@ public class CloudSpannerIT
 			log.info("Starting JDBC tests");
 			performJdbcTests();
 			log.info("JDBC tests completed");
+		}
+		catch (Exception e)
+		{
+			System.exit(ERROR);
 		}
 		finally
 		{

--- a/src/test/java/nl/topicus/jdbc/test/integration/SelectStatementsTester.java
+++ b/src/test/java/nl/topicus/jdbc/test/integration/SelectStatementsTester.java
@@ -1,10 +1,14 @@
 package nl.topicus.jdbc.test.integration;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+
+import com.google.cloud.Timestamp;
 
 import nl.topicus.jdbc.ICloudSpannerConnection;
 
@@ -49,6 +53,11 @@ public class SelectStatementsTester
 			testSelect("SELECT * FROM TEST WHERE ID IN (SELECT CHILDID FROM TESTCHILD)", 1L);
 			testSelect("SELECT * FROM TESTCHILD@{FORCE_INDEX=IDX_TESTCHILD_DESCRIPTION} WHERE DESCRIPTION LIKE ?",
 					"%CHILD%");
+			if (batchReadOnly == BATCH_READ_ONLY_TEST.YES)
+			{
+				Timestamp ts = connection.unwrap(ICloudSpannerConnection.class).getReadTimestamp();
+				assertNotNull(ts);
+			}
 			connection.commit();
 		}
 		connection.setAutoCommit(wasAutocommit);

--- a/src/test/java/nl/topicus/jdbc/test/integration/SelectStatementsTester.java
+++ b/src/test/java/nl/topicus/jdbc/test/integration/SelectStatementsTester.java
@@ -6,6 +6,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
+import nl.topicus.jdbc.ICloudSpannerConnection;
+
 /**
  * Test a variety of SELECT-statements
  * 
@@ -22,18 +24,34 @@ public class SelectStatementsTester
 		this.connection = connection;
 	}
 
+	private enum BATCH_READ_ONLY_TEST
+	{
+		YES, NO;
+	}
+
 	public void runSelectTests() throws SQLException
 	{
-		testSelect("SELECT * FROM TEST ORDER BY UUID");
-		testSelect("SELECT * FROM TEST ORDER BY UUID DESC");
-		testSelect("SELECT ID, UUID, LAST_UPDATED FROM TEST ORDER BY UUID DESC, ID");
-		testSelect("SELECT * FROM TEST WHERE ID=?", 1L);
-		testSelect("SELECT * FROM TEST ORDER BY ID LIMIT ? OFFSET ?", 2L, 10L);
-		testSelect("SELECT `ID`, `UUID`, `LAST_UPDATED` FROM `TEST` ORDER BY `UUID` DESC, `ID`");
-		testSelect("SELECT ID, UUID, LAST_UPDATED FROM TEST WHERE ID=? ORDER BY UUID DESC, ID", 1L);
-		testSelect("SELECT * FROM TEST WHERE ID IN (SELECT CHILDID FROM TESTCHILD)", 1L);
-		testSelect("SELECT * FROM TESTCHILD@{FORCE_INDEX=IDX_TESTCHILD_DESCRIPTION} WHERE DESCRIPTION LIKE ?",
-				"%CHILD%");
+		// Turn off auto commit
+		boolean wasAutocommit = connection.getAutoCommit();
+		connection.setAutoCommit(false);
+		connection.commit();
+		for (BATCH_READ_ONLY_TEST batchReadOnly : BATCH_READ_ONLY_TEST.values())
+		{
+			connection.unwrap(ICloudSpannerConnection.class)
+					.setBatchReadOnly(batchReadOnly == BATCH_READ_ONLY_TEST.YES);
+			testSelect("SELECT * FROM TEST ORDER BY UUID");
+			testSelect("SELECT * FROM TEST ORDER BY UUID DESC");
+			testSelect("SELECT ID, UUID, LAST_UPDATED FROM TEST ORDER BY UUID DESC, ID");
+			testSelect("SELECT * FROM TEST WHERE ID=?", 1L);
+			testSelect("SELECT * FROM TEST ORDER BY ID LIMIT ? OFFSET ?", 2L, 10L);
+			testSelect("SELECT `ID`, `UUID`, `LAST_UPDATED` FROM `TEST` ORDER BY `UUID` DESC, `ID`");
+			testSelect("SELECT ID, UUID, LAST_UPDATED FROM TEST WHERE ID=? ORDER BY UUID DESC, ID", 1L);
+			testSelect("SELECT * FROM TEST WHERE ID IN (SELECT CHILDID FROM TESTCHILD)", 1L);
+			testSelect("SELECT * FROM TESTCHILD@{FORCE_INDEX=IDX_TESTCHILD_DESCRIPTION} WHERE DESCRIPTION LIKE ?",
+					"%CHILD%");
+			connection.commit();
+		}
+		connection.setAutoCommit(wasAutocommit);
 	}
 
 	private void testSelect(String sql, Object... parameters) throws SQLException


### PR DESCRIPTION
Adds support for generated and named savepoints. As mutations are only sent to Cloud Spanner at commit time, rolling back to a savepoint is nothing more than discarding all buffered mutations that have been added after a specified savepoint.