### PR TITLE
#51 put a limit on the count query to determine extended mode

### DIFF
--- a/src/test/java/nl/topicus/jdbc/statement/AbstractTablePartWorkerTest.java
+++ b/src/test/java/nl/topicus/jdbc/statement/AbstractTablePartWorkerTest.java
@@ -1,0 +1,54 @@
+package nl.topicus.jdbc.statement;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.select.Select;
+import nl.topicus.jdbc.CloudSpannerConnection;
+import nl.topicus.jdbc.statement.AbstractTablePartWorker.DMLOperation;
+import nl.topicus.jdbc.test.category.UnitTest;
+
+@Category(UnitTest.class)
+public class AbstractTablePartWorkerTest
+{
+	private AbstractTablePartWorker createWorker(String sql) throws JSQLParserException
+	{
+		CloudSpannerConnection connection = mock(CloudSpannerConnection.class);
+		Select select = (Select) CCJSqlParserUtil.parse(sql);
+		ParameterStore parameters = new ParameterStore();
+		DMLOperation operation = DMLOperation.INSERT;
+		AbstractTablePartWorker worker = mock(AbstractTablePartWorker.class, withSettings()
+				.useConstructor(connection, select, parameters, true, operation).defaultAnswer(CALLS_REAL_METHODS));
+		return worker;
+	}
+
+	private String getTestCount(String sql, long batchSize) throws JSQLParserException
+	{
+		Select select = (Select) CCJSqlParserUtil.parse(sql);
+		return createWorker(select.toString()).createCountQuery(select, batchSize);
+	}
+
+	@Test
+	public void testGetEstimatedRecordCount() throws JSQLParserException
+	{
+		assertEquals("SELECT COUNT(*) AS C FROM ((SELECT * FROM FOO) LIMIT 1000) Q",
+				getTestCount("SELECT * FROM FOO", 1000L));
+		assertEquals("SELECT COUNT(*) AS C FROM ((SELECT * FROM FOO LIMIT 500) LIMIT 1000) Q",
+				getTestCount("SELECT * FROM FOO LIMIT 500", 1000L));
+		assertEquals("SELECT COUNT(*) AS C FROM ((SELECT BAR, `TEST`, bla FROM FOO) LIMIT 1000) Q",
+				getTestCount("SELECT BAR, `TEST`, bla FROM FOO", 1000L));
+		assertEquals("SELECT COUNT(*) AS C FROM ((SELECT * FROM FOO UNION ALL SELECT * FROM bar) LIMIT 1000) Q",
+				getTestCount("SELECT * FROM FOO union all select * from bar", 1000L));
+		assertEquals(
+				"SELECT COUNT(*) AS C FROM ((SELECT * FROM FOO UNION ALL SELECT * FROM bar LIMIT 500) LIMIT 1000) Q",
+				getTestCount("SELECT * FROM FOO union all select * from bar limit 500", 1000L));
+	}
+
+}

--- a/src/test/java/nl/topicus/jdbc/statement/InsertWorkerTest.java
+++ b/src/test/java/nl/topicus/jdbc/statement/InsertWorkerTest.java
@@ -50,7 +50,8 @@ public class InsertWorkerTest
 		when(countResultSet.next()).thenReturn(true, false);
 		when(countResultSet.getLong(1)).thenReturn(count);
 		when(countStatement.executeQuery()).thenReturn(countResultSet);
-		when(connection.prepareStatement("SELECT COUNT(*) AS C FROM (" + selectSQL + ") Q")).thenReturn(countStatement);
+		when(connection.prepareStatement("SELECT COUNT(*) AS C FROM ((" + selectSQL + ") LIMIT 5000) Q"))
+				.thenReturn(countStatement);
 
 		CloudSpannerPreparedStatement selectStatement = mock(CloudSpannerPreparedStatement.class);
 		CloudSpannerResultSet selectResultSet = mock(CloudSpannerResultSet.class);


### PR DESCRIPTION
The count query that determines whether an statement should be executed
in extended mode does not need to know the exact number of records, only
if the number of records is at least the threshold for entering extended
mode. Putting a limit on this query equal to the threshold speeds up the
query and prevents an exception (out of memory) from occurring in Cloud
Spanner on very big tables.