### PR TITLE
#54 keep track of type of null value parameters

### DIFF
--- a/src/main/java/nl/topicus/jdbc/statement/AbstractCloudSpannerPreparedStatement.java
+++ b/src/main/java/nl/topicus/jdbc/statement/AbstractCloudSpannerPreparedStatement.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.Calendar;
 
 import com.google.cloud.spanner.DatabaseClient;
@@ -52,97 +53,97 @@ public abstract class AbstractCloudSpannerPreparedStatement extends CloudSpanner
 	@Override
 	public void setBoolean(int parameterIndex, boolean x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.BOOLEAN);
 	}
 
 	@Override
 	public void setByte(int parameterIndex, byte x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.TINYINT);
 	}
 
 	@Override
 	public void setShort(int parameterIndex, short x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.SMALLINT);
 	}
 
 	@Override
 	public void setInt(int parameterIndex, int x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.INTEGER);
 	}
 
 	@Override
 	public void setLong(int parameterIndex, long x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.BIGINT);
 	}
 
 	@Override
 	public void setFloat(int parameterIndex, float x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.FLOAT);
 	}
 
 	@Override
 	public void setDouble(int parameterIndex, double x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.DOUBLE);
 	}
 
 	@Override
 	public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.DECIMAL);
 	}
 
 	@Override
 	public void setString(int parameterIndex, String x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.NVARCHAR);
 	}
 
 	@Override
 	public void setBytes(int parameterIndex, byte[] x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.BINARY);
 	}
 
 	@Override
 	public void setDate(int parameterIndex, Date x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.DATE);
 	}
 
 	@Override
 	public void setTime(int parameterIndex, Time x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.TIME);
 	}
 
 	@Override
 	public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.TIMESTAMP);
 	}
 
 	@Override
 	public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x, null, length);
+		parameters.setParameter(parameterIndex, x, Types.NVARCHAR, length);
 	}
 
 	@Override
 	public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x, null, length);
+		parameters.setParameter(parameterIndex, x, Types.NVARCHAR, length);
 	}
 
 	@Override
 	public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x, null, length);
+		parameters.setParameter(parameterIndex, x, Types.BINARY, length);
 	}
 
 	@Override
@@ -160,37 +161,37 @@ public abstract class AbstractCloudSpannerPreparedStatement extends CloudSpanner
 	@Override
 	public void setObject(int parameterIndex, Object x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, null);
 	}
 
 	@Override
 	public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, reader, null, length);
+		parameters.setParameter(parameterIndex, reader, Types.NVARCHAR, length);
 	}
 
 	@Override
 	public void setRef(int parameterIndex, Ref x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.REF);
 	}
 
 	@Override
 	public void setBlob(int parameterIndex, Blob x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.BLOB);
 	}
 
 	@Override
 	public void setClob(int parameterIndex, Clob x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.CLOB);
 	}
 
 	@Override
 	public void setArray(int parameterIndex, Array x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.ARRAY);
 	}
 
 	@Override
@@ -205,19 +206,19 @@ public abstract class AbstractCloudSpannerPreparedStatement extends CloudSpanner
 	@Override
 	public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.DATE);
 	}
 
 	@Override
 	public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.TIME);
 	}
 
 	@Override
 	public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.TIMESTAMP);
 	}
 
 	@Override
@@ -229,55 +230,55 @@ public abstract class AbstractCloudSpannerPreparedStatement extends CloudSpanner
 	@Override
 	public void setURL(int parameterIndex, URL x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.NVARCHAR);
 	}
 
 	@Override
 	public void setRowId(int parameterIndex, RowId x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.ROWID);
 	}
 
 	@Override
 	public void setNString(int parameterIndex, String value) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, value);
+		parameters.setParameter(parameterIndex, value, Types.NVARCHAR);
 	}
 
 	@Override
 	public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, value);
+		parameters.setParameter(parameterIndex, value, Types.NVARCHAR);
 	}
 
 	@Override
 	public void setNClob(int parameterIndex, NClob value) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, value);
+		parameters.setParameter(parameterIndex, value, Types.NCLOB);
 	}
 
 	@Override
 	public void setClob(int parameterIndex, Reader reader, long length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, reader);
+		parameters.setParameter(parameterIndex, reader, Types.CLOB);
 	}
 
 	@Override
 	public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, inputStream);
+		parameters.setParameter(parameterIndex, inputStream, Types.BLOB);
 	}
 
 	@Override
 	public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, reader);
+		parameters.setParameter(parameterIndex, reader, Types.NCLOB);
 	}
 
 	@Override
 	public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, xmlObject);
+		parameters.setParameter(parameterIndex, xmlObject, Types.SQLXML);
 	}
 
 	@Override
@@ -289,61 +290,61 @@ public abstract class AbstractCloudSpannerPreparedStatement extends CloudSpanner
 	@Override
 	public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.NVARCHAR);
 	}
 
 	@Override
 	public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.BINARY);
 	}
 
 	@Override
 	public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, reader);
+		parameters.setParameter(parameterIndex, reader, Types.NVARCHAR);
 	}
 
 	@Override
 	public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.NVARCHAR);
 	}
 
 	@Override
 	public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, x);
+		parameters.setParameter(parameterIndex, x, Types.BINARY);
 	}
 
 	@Override
 	public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, reader);
+		parameters.setParameter(parameterIndex, reader, Types.NVARCHAR);
 	}
 
 	@Override
 	public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, value);
+		parameters.setParameter(parameterIndex, value, Types.NVARCHAR);
 	}
 
 	@Override
 	public void setClob(int parameterIndex, Reader reader) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, reader);
+		parameters.setParameter(parameterIndex, reader, Types.CLOB);
 	}
 
 	@Override
 	public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, inputStream);
+		parameters.setParameter(parameterIndex, inputStream, Types.BLOB);
 	}
 
 	@Override
 	public void setNClob(int parameterIndex, Reader reader) throws SQLException
 	{
-		parameters.setParameter(parameterIndex, reader);
+		parameters.setParameter(parameterIndex, reader, Types.NVARCHAR);
 	}
 
 }

--- a/src/main/java/nl/topicus/jdbc/statement/AbstractSpannerExpressionVisitorAdapter.java
+++ b/src/main/java/nl/topicus/jdbc/statement/AbstractSpannerExpressionVisitorAdapter.java
@@ -1,5 +1,7 @@
 package nl.topicus.jdbc.statement;
 
+import java.sql.Types;
+
 import javax.xml.bind.DatatypeConverter;
 
 import net.sf.jsqlparser.expression.DateValue;
@@ -33,26 +35,26 @@ abstract class AbstractSpannerExpressionVisitorAdapter extends ExpressionVisitor
 		this.column = column;
 	}
 
-	protected abstract void setValue(Object value);
+	protected abstract void setValue(Object value, Integer sqlType);
 
 	@Override
 	public void visit(JdbcParameter parameter)
 	{
 		Object value = parameterStore.getParameter(parameter.getIndex());
 		parameterStore.setColumn(parameter.getIndex(), column);
-		setValue(value);
+		setValue(value, parameterStore.getType(parameter.getIndex()));
 	}
 
 	@Override
 	public void visit(NullValue value)
 	{
-		setValue(null);
+		setValue(null, null);
 	}
 
 	@Override
 	public void visit(DoubleValue value)
 	{
-		setValue(value.getValue());
+		setValue(value.getValue(), Types.DOUBLE);
 	}
 
 	@Override
@@ -80,31 +82,31 @@ abstract class AbstractSpannerExpressionVisitorAdapter extends ExpressionVisitor
 	@Override
 	public void visit(LongValue value)
 	{
-		setValue(value.getValue());
+		setValue(value.getValue(), Types.BIGINT);
 	}
 
 	@Override
 	public void visit(DateValue value)
 	{
-		setValue(value.getValue());
+		setValue(value.getValue(), Types.DATE);
 	}
 
 	@Override
 	public void visit(TimeValue value)
 	{
-		setValue(value.getValue());
+		setValue(value.getValue(), Types.TIME);
 	}
 
 	@Override
 	public void visit(TimestampValue value)
 	{
-		setValue(value.getValue());
+		setValue(value.getValue(), Types.TIMESTAMP);
 	}
 
 	@Override
 	public void visit(StringValue value)
 	{
-		setValue(value.getValue());
+		setValue(value.getValue(), Types.NVARCHAR);
 	}
 
 	@Override
@@ -112,7 +114,7 @@ abstract class AbstractSpannerExpressionVisitorAdapter extends ExpressionVisitor
 	{
 		String stringValue = value.getValue().substring(2);
 		byte[] byteValue = DatatypeConverter.parseHexBinary(stringValue);
-		setValue(byteValue);
+		setValue(byteValue, Types.BINARY);
 	}
 
 	/**
@@ -126,7 +128,7 @@ abstract class AbstractSpannerExpressionVisitorAdapter extends ExpressionVisitor
 		String stringValue = column.getColumnName();
 		if (stringValue.equalsIgnoreCase("true") || stringValue.equalsIgnoreCase("false"))
 		{
-			setValue(Boolean.valueOf(stringValue));
+			setValue(Boolean.valueOf(stringValue), Types.BOOLEAN);
 		}
 	}
 

--- a/src/main/java/nl/topicus/jdbc/statement/CloudSpannerPreparedStatement.java
+++ b/src/main/java/nl/topicus/jdbc/statement/CloudSpannerPreparedStatement.java
@@ -239,7 +239,7 @@ public class CloudSpannerPreparedStatement extends AbstractCloudSpannerPreparedS
 		{
 			ValueBinderExpressionVisitorAdapter<com.google.cloud.spanner.Statement.Builder> binder = new ValueBinderExpressionVisitorAdapter<>(
 					getParameterStore(), builder.bind("p" + getParameterStore().getHighestIndex()), null);
-			binder.setValue(getParameterStore().getParameter(getParameterStore().getHighestIndex()));
+			binder.setValue(getParameterStore().getParameter(getParameterStore().getHighestIndex()), Types.BIGINT);
 			getParameterStore().setType(getParameterStore().getHighestIndex(), Types.BIGINT);
 		}
 	}

--- a/src/main/java/nl/topicus/jdbc/statement/KeyBuilderExpressionVisitorAdapter.java
+++ b/src/main/java/nl/topicus/jdbc/statement/KeyBuilderExpressionVisitorAdapter.java
@@ -11,7 +11,7 @@ class KeyBuilderExpressionVisitorAdapter extends AbstractSpannerExpressionVisito
 	}
 
 	@Override
-	protected void setValue(Object value)
+	protected void setValue(Object value, Integer sqlType)
 	{
 		keyBuilder.to(value);
 	}

--- a/src/main/java/nl/topicus/jdbc/statement/ParameterStore.java
+++ b/src/main/java/nl/topicus/jdbc/statement/ParameterStore.java
@@ -99,7 +99,7 @@ public class ParameterStore
 				getColumn(parameterIndex));
 	}
 
-	void setParameter(int parameterIndex, Object value)
+	void setParameter(int parameterIndex, Object value, Integer sqlType)
 	{
 		setParameter(parameterIndex, value, null, null);
 	}

--- a/src/main/java/nl/topicus/jdbc/statement/SingleRowWhereClauseValidatorExpressionVisitorAdapter.java
+++ b/src/main/java/nl/topicus/jdbc/statement/SingleRowWhereClauseValidatorExpressionVisitorAdapter.java
@@ -12,7 +12,7 @@ class SingleRowWhereClauseValidatorExpressionVisitorAdapter extends AbstractSpan
 	}
 
 	@Override
-	protected void setValue(Object value)
+	protected void setValue(Object value, Integer sqlType)
 	{
 		validator.to(value);
 	}

--- a/src/main/java/nl/topicus/jdbc/statement/ValueBinderExpressionVisitorAdapter.java
+++ b/src/main/java/nl/topicus/jdbc/statement/ValueBinderExpressionVisitorAdapter.java
@@ -7,6 +7,7 @@ import java.sql.Array;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
 
@@ -29,9 +30,9 @@ class ValueBinderExpressionVisitorAdapter<R> extends AbstractSpannerExpressionVi
 	}
 
 	@Override
-	protected void setValue(Object value)
+	protected void setValue(Object value, Integer sqlType)
 	{
-		R res = setSingleValue(value);
+		R res = setSingleValue(value, sqlType);
 		if (res == null && value != null)
 			res = setArrayValue(value);
 
@@ -42,12 +43,11 @@ class ValueBinderExpressionVisitorAdapter<R> extends AbstractSpannerExpressionVi
 		}
 	}
 
-	private R setSingleValue(Object value)
+	private R setSingleValue(Object value, Integer sqlType)
 	{
 		if (value == null)
 		{
-			// Set to null, type does not matter
-			return binder.to((Boolean) null);
+			return setNullValue(sqlType);
 		}
 		else if (Boolean.class.isAssignableFrom(value.getClass()))
 		{
@@ -216,6 +216,71 @@ class ValueBinderExpressionVisitorAdapter<R> extends AbstractSpannerExpressionVi
 			return binder.toBytesArray(CloudSpannerConversionUtil.toCloudSpannerBytes((byte[][]) value));
 		}
 		return null;
+	}
+
+	private R setNullValue(Integer sqlType)
+	{
+		if (sqlType == null)
+		{
+			return binder.to((String) null);
+		}
+		switch (sqlType)
+		{
+		case Types.BIGINT:
+			return binder.to((Long) null);
+		case Types.BINARY:
+			return binder.to((ByteArray) null);
+		case Types.BLOB:
+			return binder.to((ByteArray) null);
+		case Types.BOOLEAN:
+			return binder.to((Boolean) null);
+		case Types.CHAR:
+			return binder.to((String) null);
+		case Types.CLOB:
+			return binder.to((String) null);
+		case Types.DATE:
+			return binder.to((com.google.cloud.Date) null);
+		case Types.DECIMAL:
+			return binder.to((Double) null);
+		case Types.DOUBLE:
+			return binder.to((Double) null);
+		case Types.FLOAT:
+			return binder.to((Double) null);
+		case Types.INTEGER:
+			return binder.to((Long) null);
+		case Types.LONGNVARCHAR:
+			return binder.to((String) null);
+		case Types.LONGVARBINARY:
+			return binder.to((ByteArray) null);
+		case Types.LONGVARCHAR:
+			return binder.to((String) null);
+		case Types.NCHAR:
+			return binder.to((String) null);
+		case Types.NCLOB:
+			return binder.to((String) null);
+		case Types.NUMERIC:
+			return binder.to((Double) null);
+		case Types.NVARCHAR:
+			return binder.to((String) null);
+		case Types.REAL:
+			return binder.to((Double) null);
+		case Types.SMALLINT:
+			return binder.to((Long) null);
+		case Types.SQLXML:
+			return binder.to((String) null);
+		case Types.TIME:
+			return binder.to((com.google.cloud.Timestamp) null);
+		case Types.TIMESTAMP:
+			return binder.to((com.google.cloud.Timestamp) null);
+		case Types.TINYINT:
+			return binder.to((Long) null);
+		case Types.VARBINARY:
+			return binder.to((ByteArray) null);
+		case Types.VARCHAR:
+			return binder.to((String) null);
+		default:
+			throw new IllegalArgumentException("Unsupported sql type: " + sqlType);
+		}
 	}
 
 }

--- a/src/test/java/nl/topicus/jdbc/statement/ValueBinderExpressionVisitorAdapterTest.java
+++ b/src/test/java/nl/topicus/jdbc/statement/ValueBinderExpressionVisitorAdapterTest.java
@@ -1,6 +1,7 @@
 package nl.topicus.jdbc.statement;
 
 import java.math.BigDecimal;
+import java.sql.Types;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -28,36 +29,36 @@ public class ValueBinderExpressionVisitorAdapterTest
 	@Test
 	public void testSetValueWithoutException()
 	{
-		create().setValue(null);
-		create().setValue((byte) 1);
-		create().setValue((short) 1);
-		create().setValue(1);
-		create().setValue(1l);
-		create().setValue(1f);
-		create().setValue(1d);
-		create().setValue('a');
-		create().setValue(true);
-		create().setValue("TEST");
-		create().setValue(BigDecimal.ONE);
-		create().setValue(new byte[] { (byte) 1 });
+		create().setValue(null, Types.BOOLEAN);
+		create().setValue((byte) 1, Types.TINYINT);
+		create().setValue((short) 1, Types.SMALLINT);
+		create().setValue(1, Types.INTEGER);
+		create().setValue(1l, Types.BIGINT);
+		create().setValue(1f, Types.FLOAT);
+		create().setValue(1d, Types.DOUBLE);
+		create().setValue('a', Types.CHAR);
+		create().setValue(true, Types.BOOLEAN);
+		create().setValue("TEST", Types.NVARCHAR);
+		create().setValue(BigDecimal.ONE, Types.DECIMAL);
+		create().setValue(new byte[] { (byte) 1 }, Types.BINARY);
 
-		create().setValue(new short[] { (short) 1 });
-		create().setValue(new Short[] { (short) 1 });
-		create().setValue(new int[] { 1 });
-		create().setValue(new Integer[] { 1 });
-		create().setValue(new long[] { 1l });
-		create().setValue(new Long[] { 1l });
-		create().setValue(new float[] { 1f });
-		create().setValue(new Float[] { 1f });
-		create().setValue(new double[] { 1d });
-		create().setValue(new Double[] { 1d });
-		create().setValue(new char[] { 'a' });
-		create().setValue(new Character[] { 'a' });
-		create().setValue(new boolean[] { true });
-		create().setValue(new Boolean[] { true });
-		create().setValue(new String[] { "TEST" });
-		create().setValue(new BigDecimal[] { BigDecimal.ONE });
-		create().setValue(new byte[][] { { (byte) 1 } });
+		create().setValue(new short[] { (short) 1 }, Types.ARRAY);
+		create().setValue(new Short[] { (short) 1 }, Types.ARRAY);
+		create().setValue(new int[] { 1 }, Types.ARRAY);
+		create().setValue(new Integer[] { 1 }, Types.ARRAY);
+		create().setValue(new long[] { 1l }, Types.ARRAY);
+		create().setValue(new Long[] { 1l }, Types.ARRAY);
+		create().setValue(new float[] { 1f }, Types.ARRAY);
+		create().setValue(new Float[] { 1f }, Types.ARRAY);
+		create().setValue(new double[] { 1d }, Types.ARRAY);
+		create().setValue(new Double[] { 1d }, Types.ARRAY);
+		create().setValue(new char[] { 'a' }, Types.ARRAY);
+		create().setValue(new Character[] { 'a' }, Types.ARRAY);
+		create().setValue(new boolean[] { true }, Types.ARRAY);
+		create().setValue(new Boolean[] { true }, Types.ARRAY);
+		create().setValue(new String[] { "TEST" }, Types.ARRAY);
+		create().setValue(new BigDecimal[] { BigDecimal.ONE }, Types.ARRAY);
+		create().setValue(new byte[][] { { (byte) 1 } }, Types.ARRAY);
 
 	}
 


### PR DESCRIPTION
When a parameter value is set to null, the type of the parameter must also be set to a correct type and sent to Cloud Spanner. Otherwise, Cloud Spanner will complain about invalid type conversions.