### PR TITLE
#56 add support for array literals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<properties>
 		<java.version>1.8</java.version>
@@ -48,12 +49,17 @@
 			<artifactId>json</artifactId>
 			<version>20171018</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.7</version>
+		</dependency>
 		<dependency>
 			<groupId>com.github.jsqlparser</groupId>
 			<artifactId>jsqlparser</artifactId>
 			<version>1.1</version>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
@@ -213,7 +219,8 @@
 								</excludes>
 							</artifactSet>
 							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
 							</transformers>
 							<relocations>
 								<relocation>

--- a/src/main/java/nl/topicus/jdbc/statement/ValueBinderExpressionVisitorAdapter.java
+++ b/src/main/java/nl/topicus/jdbc/statement/ValueBinderExpressionVisitorAdapter.java
@@ -10,7 +10,11 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.math.NumberUtils;
+
+import com.google.api.client.util.DateTime;
 import com.google.cloud.ByteArray;
 import com.google.cloud.spanner.ValueBinder;
 import com.google.common.primitives.Booleans;
@@ -21,6 +25,8 @@ import nl.topicus.jdbc.util.CloudSpannerConversionUtil;
 
 class ValueBinderExpressionVisitorAdapter<R> extends AbstractSpannerExpressionVisitorAdapter
 {
+	private static final Pattern SPLIT_ON_COMMA_PATTERN = Pattern.compile(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
+
 	private ValueBinder<R> binder;
 
 	ValueBinderExpressionVisitorAdapter(ParameterStore parameterStore, ValueBinder<R> binder, String column)
@@ -93,7 +99,16 @@ class ValueBinderExpressionVisitorAdapter<R> extends AbstractSpannerExpressionVi
 		}
 		else if (String.class.isAssignableFrom(value.getClass()))
 		{
-			return binder.to((String) value);
+			String stringVal = (String) value;
+			if (stringVal.startsWith("{") && stringVal.endsWith("}"))
+			{
+				R res = splitAndSetArrayValue(stringVal);
+				if (res != null)
+				{
+					return res;
+				}
+			}
+			return binder.to(stringVal);
 		}
 		else if (Character.class.isAssignableFrom(value.getClass()))
 		{
@@ -137,6 +152,219 @@ class ValueBinderExpressionVisitorAdapter<R> extends AbstractSpannerExpressionVi
 			}
 		}
 		return null;
+	}
+
+	private R splitAndSetArrayValue(String arrayString)
+	{
+		// Split on comma's, do not include '{' and '}'
+		String[] array = SPLIT_ON_COMMA_PATTERN.split(arrayString.substring(1, arrayString.length() - 1));
+		// Trim the array elements
+		for (int i = 0; i < array.length; i++)
+			array[i] = array[i] == null ? null : array[i].trim();
+		// Try to determine the data type of the array
+		if (isStringArray(array))
+		{
+			return setArrayValue(convertStringArray(array));
+		}
+		else if (isBooleanArray(array))
+		{
+			return setArrayValue(convertBooleanArray(array));
+		}
+		else if (isLongArray(array))
+		{
+			return setArrayValue(convertLongArray(array));
+		}
+		else if (isDoubleArray(array))
+		{
+			return setArrayValue(convertDoubleArray(array));
+		}
+		else if (isDateArray(array))
+		{
+			return setArrayValue(convertDateArray(array));
+		}
+		else if (isTimestampArray(array))
+		{
+			return setArrayValue(convertTimestampArray(array));
+		}
+		return null;
+	}
+
+	private boolean isStringArray(String[] array)
+	{
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				if (!(val.startsWith("\"") && val.endsWith("\"")))
+				{
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	private String[] convertStringArray(String[] array)
+	{
+		int index = 0;
+		String[] res = new String[array.length];
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				res[index] = val.substring(1, val.length() - 1);
+			}
+			index++;
+		}
+		return res;
+	}
+
+	private boolean isBooleanArray(String[] array)
+	{
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				if (!(val.equalsIgnoreCase("true") || val.equalsIgnoreCase("false")))
+				{
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	private Boolean[] convertBooleanArray(String[] array)
+	{
+		int index = 0;
+		Boolean[] res = new Boolean[array.length];
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				res[index] = Boolean.valueOf(val);
+			}
+			index++;
+		}
+		return res;
+	}
+
+	private boolean isLongArray(String[] array)
+	{
+		for (String val : array)
+		{
+			if (!NumberUtils.isDigits(val))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private Long[] convertLongArray(String[] array)
+	{
+		int index = 0;
+		Long[] res = new Long[array.length];
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				res[index] = NumberUtils.createNumber(val).longValue();
+			}
+			index++;
+		}
+		return res;
+	}
+
+	private boolean isDoubleArray(String[] array)
+	{
+		for (String val : array)
+		{
+			if (!NumberUtils.isCreatable(val))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private Double[] convertDoubleArray(String[] array)
+	{
+		int index = 0;
+		Double[] res = new Double[array.length];
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				res[index] = NumberUtils.createNumber(val).doubleValue();
+			}
+			index++;
+		}
+		return res;
+	}
+
+	private boolean isDateArray(String[] array)
+	{
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				if (!(val.startsWith("{d \"") && val.endsWith("\"}")))
+				{
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	private Date[] convertDateArray(String[] array)
+	{
+		int index = 0;
+		Date[] res = new Date[array.length];
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				String date = val.substring(4, val.length() - 2);
+				res[index] = new Date(DateTime.parseRfc3339(date).getValue());
+			}
+			index++;
+		}
+		return res;
+	}
+
+	private boolean isTimestampArray(String[] array)
+	{
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				if (!(val.startsWith("{ts \"") && val.endsWith("\"}")))
+				{
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	private Timestamp[] convertTimestampArray(String[] array)
+	{
+		int index = 0;
+		Timestamp[] res = new Timestamp[array.length];
+		for (String val : array)
+		{
+			if (val != null)
+			{
+				String date = val.substring(5, val.length() - 2).replace(' ', 'T');
+				if (!date.endsWith("Z"))
+					date = date + "Z";
+				res[index] = com.google.cloud.Timestamp.parseTimestamp(date).toSqlTimestamp();
+			}
+			index++;
+		}
+		return res;
 	}
 
 	private R setArrayValue(Object value)


### PR DESCRIPTION
Arrays were only supported through JDBC parameters and not as literals. This PR introduces support for array literals for all data types except BYTES.