### PR TITLE
#77 isWritable and related methods returned false for pk columns

### DIFF
--- a/src/main/java/nl/topicus/jdbc/resultset/CloudSpannerResultSetMetaData.java
+++ b/src/main/java/nl/topicus/jdbc/resultset/CloudSpannerResultSetMetaData.java
@@ -468,22 +468,9 @@ public class CloudSpannerResultSetMetaData extends AbstractCloudSpannerWrapper i
 		Column col = getColumn(column);
 		if (col == null || col.getTable() == null)
 			return true;
-		// Primary key columns are always read-only, all other columns are
-		// writable.
-		String schema = Strings.isNullOrEmpty(col.getTable().getSchemaName()) ? ""
-				: CloudSpannerDriver.unquoteIdentifier(col.getTable().getSchemaName());
-		String tableName = CloudSpannerDriver.unquoteIdentifier(col.getTable().getName());
-		String colName = CloudSpannerDriver.unquoteIdentifier(col.getColumnName());
-		try (java.sql.ResultSet rs = statement.getConnection().getMetaData().getPrimaryKeys("", schema, tableName))
-		{
-			while (rs.next())
-			{
-				if (rs.getString("COLUMN_NAME").equalsIgnoreCase(colName))
-				{
-					return true;
-				}
-			}
-		}
+		// Primary key columns are only insertable and never updatable, all
+		// other columns are insertable and updatable. This however still means
+		// that a primary key column is writable.
 		return false;
 	}
 

--- a/src/test/java/nl/topicus/jdbc/resultset/CloudSpannerResultSetMetaDataTest.java
+++ b/src/test/java/nl/topicus/jdbc/resultset/CloudSpannerResultSetMetaDataTest.java
@@ -546,27 +546,24 @@ public class CloudSpannerResultSetMetaDataTest
 	@Test
 	public void testIsReadOnly() throws SQLException
 	{
-		assertTrue(subject.isReadOnly(1));
 		assertTrue(subject.isReadOnly(TEST_COLUMNS.size()));
-		for (int i = 2; i < TEST_COLUMNS.size(); i++)
+		for (int i = 1; i < TEST_COLUMNS.size(); i++)
 			assertFalse(subject.isReadOnly(i));
 	}
 
 	@Test
 	public void testIsWritable() throws SQLException
 	{
-		assertFalse(subject.isWritable(1));
 		assertFalse(subject.isWritable(TEST_COLUMNS.size()));
-		for (int i = 2; i < TEST_COLUMNS.size(); i++)
+		for (int i = 1; i < TEST_COLUMNS.size(); i++)
 			assertTrue(subject.isWritable(i));
 	}
 
 	@Test
 	public void testIsDefinitelyWritable() throws SQLException
 	{
-		assertFalse(subject.isDefinitelyWritable(1));
 		assertFalse(subject.isDefinitelyWritable(TEST_COLUMNS.size()));
-		for (int i = 2; i < TEST_COLUMNS.size(); i++)
+		for (int i = 1; i < TEST_COLUMNS.size(); i++)
 			assertTrue(subject.isDefinitelyWritable(i));
 	}
 


### PR DESCRIPTION
isWritable, isDefinitelyWritable and isReadOnly considered primary key columns as read-only. This is not really true, as primary key columns are writable during an insert, but not updatable later. The columns themselves are therefore writable (they are not computed or derived columns), but the value cannot be changed once it has been written.