### PR TITLE
#spanner-beam-example/1 fix beam example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<properties>
 		<java.version>1.8</java.version>
@@ -44,6 +45,11 @@
 			<version>0.42.0-beta</version>
 		</dependency>
 		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-storage</artifactId>
+			<version>1.37.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
 			<version>20171018</version>
@@ -58,7 +64,7 @@
 			<artifactId>jsqlparser</artifactId>
 			<version>1.1</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
@@ -218,7 +224,8 @@
 								</excludes>
 							</artifactSet>
 							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
 							</transformers>
 							<relocations>
 								<relocation>

--- a/src/main/java/nl/topicus/jdbc/CloudSpannerConnection.java
+++ b/src/main/java/nl/topicus/jdbc/CloudSpannerConnection.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.Channels;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -33,6 +34,7 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
+import com.google.cloud.ReadChannel;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.BatchClient;
 import com.google.cloud.spanner.DatabaseAdminClient;
@@ -47,6 +49,9 @@ import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.rpc.Code;
@@ -285,17 +290,53 @@ public class CloudSpannerConnection extends AbstractCloudSpannerConnection
 		if (credentialsPath == null || credentialsPath.length() == 0)
 			throw new IllegalArgumentException("credentialsPath may not be null or empty");
 		GoogleCredentials credentials = null;
-		File credentialsFile = new File(credentialsPath);
-		if (!credentialsFile.isFile())
+		if (credentialsPath.startsWith("gs://"))
 		{
-			throw new IOException(
-					String.format("Error reading credential file %s: File does not exist", credentialsPath));
+			try
+			{
+				Storage storage = StorageOptions.newBuilder().build().getService();
+				String bucketName = getBucket(credentialsPath);
+				String blobName = getBlob(credentialsPath);
+				Blob blob = storage.get(bucketName, blobName);
+				ReadChannel reader = blob.reader();
+				InputStream inputStream = Channels.newInputStream(reader);
+				credentials = GoogleCredentials.fromStream(inputStream, CloudSpannerOAuthUtil.HTTP_TRANSPORT_FACTORY);
+			}
+			catch (Exception e)
+			{
+				throw new IllegalArgumentException(
+						"Invalid credentials path: " + credentialsPath + ". Reason: " + e.getMessage(), e);
+			}
 		}
-		try (InputStream credentialsStream = new FileInputStream(credentialsFile))
+		else
 		{
-			credentials = GoogleCredentials.fromStream(credentialsStream, CloudSpannerOAuthUtil.HTTP_TRANSPORT_FACTORY);
+			File credentialsFile = new File(credentialsPath);
+			if (!credentialsFile.isFile())
+			{
+				throw new IOException(
+						String.format("Error reading credential file %s: File does not exist", credentialsPath));
+			}
+			try (InputStream credentialsStream = new FileInputStream(credentialsFile))
+			{
+				credentials = GoogleCredentials.fromStream(credentialsStream,
+						CloudSpannerOAuthUtil.HTTP_TRANSPORT_FACTORY);
+			}
 		}
 		return credentials;
+	}
+
+	static String getBucket(String storageUrl)
+	{
+		Preconditions.checkArgument(storageUrl.startsWith("gs://"), "Storage URL must start with gs://");
+		Preconditions.checkArgument(storageUrl.substring(5).contains("/"), "Storage URL must contain a blob name");
+		return storageUrl.substring(5, storageUrl.indexOf('/', 5));
+	}
+
+	static String getBlob(String storageUrl)
+	{
+		Preconditions.checkArgument(storageUrl.startsWith("gs://"), "Storage URL must start with gs://");
+		Preconditions.checkArgument(storageUrl.substring(5).contains("/"), "Storage URL must contain a blob name");
+		return storageUrl.substring(storageUrl.indexOf('/', 5) + 1);
 	}
 
 	public static String getServiceAccountProjectId(String credentialsPath)

--- a/src/test/java/nl/topicus/jdbc/CloudSpannerConnectionTest.java
+++ b/src/test/java/nl/topicus/jdbc/CloudSpannerConnectionTest.java
@@ -430,4 +430,16 @@ public class CloudSpannerConnectionTest
 		Assert.assertTrue("Method did not throw exception on closed connection", valid);
 	}
 
+	@Test
+	public void testGetBucket()
+	{
+		assertEquals("test-bucket", CloudSpannerConnection.getBucket("gs://test-bucket/config/key.json"));
+	}
+
+	@Test
+	public void testGetBlob()
+	{
+		assertEquals("config/key.json", CloudSpannerConnection.getBlob("gs://test-bucket/config/key.json"));
+	}
+
 }

--- a/src/test/java/nl/topicus/jdbc/test/integration/xa/XATester.java
+++ b/src/test/java/nl/topicus/jdbc/test/integration/xa/XATester.java
@@ -21,6 +21,7 @@ import com.google.rpc.Code;
 import nl.topicus.jdbc.CloudSpannerDriver;
 import nl.topicus.jdbc.CloudSpannerXADataSource;
 import nl.topicus.jdbc.exception.CloudSpannerSQLException;
+import nl.topicus.jdbc.test.integration.CloudSpannerIT;
 import nl.topicus.jdbc.xa.CloudSpannerXAConnection;
 import nl.topicus.jdbc.xa.RecoveredXid;
 
@@ -39,6 +40,8 @@ public class XATester
 		int originalLogLevel = CloudSpannerDriver.getLogLevel();
 		CloudSpannerDriver.setLogLevel(CloudSpannerDriver.DEBUG);
 		CloudSpannerXADataSource ds = new CloudSpannerXADataSource();
+		ds.setHost(CloudSpannerIT.getHost());
+		ds.setUseCustomHost(true);
 		ds.setProjectId(projectId);
 		ds.setInstanceId(instanceId);
 		ds.setDatabase(database);


### PR DESCRIPTION
The beam example did not work (anymore) with version 2.5.0 of
apache-beam. Also, this fix introduces support for getting a key file
from a google storage bucket, as that makes it easier to specify a key
file when using an external runner such as the Dataflow runner.