### PR TITLE
#105 added better error message for calling functions client side

### DIFF
--- a/src/main/java/nl/topicus/jdbc/statement/AbstractSpannerExpressionVisitorAdapter.java
+++ b/src/main/java/nl/topicus/jdbc/statement/AbstractSpannerExpressionVisitorAdapter.java
@@ -2,6 +2,7 @@ package nl.topicus.jdbc.statement;
 
 import java.sql.Types;
 import javax.xml.bind.DatatypeConverter;
+import com.google.rpc.Code;
 import net.sf.jsqlparser.expression.DateValue;
 import net.sf.jsqlparser.expression.DoubleValue;
 import net.sf.jsqlparser.expression.Expression;
@@ -12,9 +13,11 @@ import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.expression.NullValue;
 import net.sf.jsqlparser.expression.SignedExpression;
 import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.expression.TimeKeyExpression;
 import net.sf.jsqlparser.expression.TimeValue;
 import net.sf.jsqlparser.expression.TimestampValue;
 import net.sf.jsqlparser.schema.Column;
+import nl.topicus.jdbc.exception.CloudSpannerSQLException;
 
 abstract class AbstractSpannerExpressionVisitorAdapter extends ExpressionVisitorAdapter {
   private ParameterStore parameterStore;
@@ -109,6 +112,13 @@ abstract class AbstractSpannerExpressionVisitorAdapter extends ExpressionVisitor
     if (stringValue.equalsIgnoreCase("true") || stringValue.equalsIgnoreCase("false")) {
       setValue(Boolean.valueOf(stringValue), Types.BOOLEAN);
     }
+  }
+
+  @Override
+  public void visit(TimeKeyExpression timeKeyExpression) {
+    throw new IllegalArgumentException(new CloudSpannerSQLException(
+        "Function calls such as for example GET_TIMESTAMP() are not allowed in client side insert/update statements. Use an insert statement with a select statement instead: INSERT INTO COL1, COL2, COL3 SELECT 1, GET_TIMESTAMP(), 'test'",
+        Code.INVALID_ARGUMENT));
   }
 
 }

--- a/src/test/java/nl/topicus/jdbc/statement/CloudSpannerStatementTest.java
+++ b/src/test/java/nl/topicus/jdbc/statement/CloudSpannerStatementTest.java
@@ -19,6 +19,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.Returns;
 import nl.topicus.jdbc.CloudSpannerConnection;
+import nl.topicus.jdbc.exception.CloudSpannerSQLException;
 import nl.topicus.jdbc.statement.CloudSpannerStatement.BatchMode;
 import nl.topicus.jdbc.test.category.UnitTest;
 import nl.topicus.jdbc.test.util.CloudSpannerTestObjects;
@@ -308,6 +309,19 @@ public class CloudSpannerStatementTest {
     try (ResultSet rs = statement.getGeneratedKeys()) {
       assertFalse(rs.next());
     }
+  }
+
+  @Test
+  public void testInsertWithGetTimestamp() throws SQLException {
+    thrown.expect(CloudSpannerSQLException.class);
+    thrown.expectMessage(
+        "Function calls such as for example GET_TIMESTAMP() are not allowed in client side insert/update statements");
+    CloudSpannerConnection connection = createConnection();
+    CloudSpannerStatement statement = connection.createStatement();
+    String sql = "INSERT INTO providers\n"
+        + "(provider_id, created, device_id, document_number, document_type_id, name, notification, phone, updated, last_access, deleted, token_fcm)\n"
+        + "VALUES('000000', CURRENT_DATE(), 'not-device-id', null, null, 'provider-promocion', false, null, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), false, 'not-token')";
+    statement.execute(sql);
   }
 
 }

--- a/src/test/java/nl/topicus/jdbc/test/integration/specific/InsertStatementWithGetTimestampIT.java
+++ b/src/test/java/nl/topicus/jdbc/test/integration/specific/InsertStatementWithGetTimestampIT.java
@@ -1,0 +1,40 @@
+package nl.topicus.jdbc.test.integration.specific;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import nl.topicus.jdbc.test.category.IntegrationTest;
+
+@Category(IntegrationTest.class)
+public class InsertStatementWithGetTimestampIT extends AbstractSpecificIntegrationTest {
+
+  @Before
+  public void before() throws SQLException {
+    String sql =
+        "CREATE TABLE providers (provider_id string(100) not null, created date not null, device_id string(100) not null, "
+            + "document_number int64, document_type_id int64, name string(100) not null, notification bool not null, "
+            + "phone string(100), updated timestamp not null, last_access timestamp, deleted bool not null, token_fcm string(100)) primary key (provider_id)";
+    getConnection().createStatement().execute(sql);
+  }
+
+  @After
+  public void after() throws SQLException {
+    String sql = "DROP TABLE providers";
+    getConnection().createStatement().execute(sql);
+  }
+
+  @Test
+  public void testInsertWithGetTimestampWithSelect() throws SQLException {
+    Connection connection = getConnection();
+    Statement statement = connection.createStatement();
+    String sql = "INSERT INTO providers\n"
+        + "(provider_id, created, device_id, document_number, document_type_id, name, notification, phone, updated, last_access, deleted, token_fcm)\n"
+        + "SELECT '000000', CURRENT_DATE(), 'not-device-id', null, null, 'provider-promocion', false, null, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), false, 'not-token'";
+    statement.execute(sql);
+  }
+
+}


### PR DESCRIPTION
Mutations that are handled entirely client side may not call Cloud Spanner functions such as for example GET_TIMESTAMP().