### PR TITLE
#112 setting a parameter with a high index could cause an exception

### DIFF
--- a/src/main/java/nl/topicus/jdbc/statement/ParameterStore.java
+++ b/src/main/java/nl/topicus/jdbc/statement/ParameterStore.java
@@ -101,12 +101,12 @@ public class ParameterStore {
     highestIndex = Math.max(parameterIndex, highestIndex);
     int arrayIndex = parameterIndex - 1;
     if (arrayIndex >= parameters.length) {
-      parameters = Arrays.copyOf(parameters, Math.max(parameters.length * 2, arrayIndex));
-      types = Arrays.copyOf(types, Math.max(types.length * 2, arrayIndex));
-      nullable = Arrays.copyOf(nullable, Math.max(nullable.length * 2, arrayIndex));
+      parameters = Arrays.copyOf(parameters, Math.max(parameters.length * 2, arrayIndex + 1));
+      types = Arrays.copyOf(types, Math.max(types.length * 2, arrayIndex + 1));
+      nullable = Arrays.copyOf(nullable, Math.max(nullable.length * 2, arrayIndex + 1));
       scalesOrLengths =
-          Arrays.copyOf(scalesOrLengths, Math.max(scalesOrLengths.length * 2, arrayIndex));
-      columns = Arrays.copyOf(columns, Math.max(columns.length * 2, arrayIndex));
+          Arrays.copyOf(scalesOrLengths, Math.max(scalesOrLengths.length * 2, arrayIndex + 1));
+      columns = Arrays.copyOf(columns, Math.max(columns.length * 2, arrayIndex + 1));
     }
     parameters[arrayIndex] = value;
     types[arrayIndex] = sqlType;

--- a/src/test/java/nl/topicus/jdbc/statement/CloudSpannerPreparedStatementTest.java
+++ b/src/test/java/nl/topicus/jdbc/statement/CloudSpannerPreparedStatementTest.java
@@ -1033,6 +1033,14 @@ public class CloudSpannerPreparedStatementTest {
       ps.setNull(1, Types.ARRAY);
       ps.getParameterMetaData();
     }
+
+    @Test
+    public void setHighParameterIndex() throws SQLException {
+      String sql = "INSERT INTO FOO (ID, COL1, COL2) VALUES (?, ?, ?)";
+      CloudSpannerPreparedStatement ps = CloudSpannerTestObjects.createPreparedStatement(sql);
+      // This used to cause an ArrayOutOfBoundsException
+      ps.setLong(21, 100L);
+    }
   }
 
   public static class SelectStatementTests {


### PR DESCRIPTION
Setting a parameter with an index higher than 2 times the current number of positions reserved for 
parameters values internally in the driver would cause an ArrayOutOfBoundsException