### PR TITLE
#110 parameters were not included in extended mode query

### DIFF
--- a/src/test/java/nl/topicus/jdbc/test/integration/specific/AbstractSpecificIntegrationTest.java
+++ b/src/test/java/nl/topicus/jdbc/test/integration/specific/AbstractSpecificIntegrationTest.java
@@ -3,6 +3,7 @@ package nl.topicus.jdbc.test.integration.specific;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Random;
@@ -153,6 +154,12 @@ public abstract class AbstractSpecificIntegrationTest {
     if (connection != null) {
       connection.close();
       connection = null;
+    }
+  }
+
+  protected boolean tableExists(String name) throws SQLException {
+    try (ResultSet rs = getConnection().getMetaData().getTables(null, null, name, null)) {
+      return rs.next();
     }
   }
 

--- a/src/test/java/nl/topicus/jdbc/test/integration/specific/ExtendedModeIT.java
+++ b/src/test/java/nl/topicus/jdbc/test/integration/specific/ExtendedModeIT.java
@@ -1,0 +1,112 @@
+package nl.topicus.jdbc.test.integration.specific;
+
+import static org.junit.Assert.assertEquals;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.MethodSorters;
+import nl.topicus.jdbc.CloudSpannerConnection;
+import nl.topicus.jdbc.test.category.IntegrationTest;
+
+@Category(IntegrationTest.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ExtendedModeIT extends AbstractSpecificIntegrationTest {
+  private static final int NUMBER_OF_ROWS = 100;
+
+  @Before
+  public void createAndFillTestTable() throws SQLException {
+    if (tableExists("test"))
+      return;
+    getConnection().createStatement().execute(
+        "create table test (id int64 not null, name string(100) not null) primary key (id)");
+    getConnection().setAutoCommit(false);
+    PreparedStatement ps =
+        getConnection().prepareStatement("insert into test (id, name) values (?,?)");
+    for (int i = 0; i < NUMBER_OF_ROWS; i++) {
+      ps.setLong(1, i);
+      ps.setString(2, String.valueOf(i));
+      ps.addBatch();
+    }
+    ps.executeBatch();
+    getConnection().commit();
+  }
+
+  @Test
+  public void test1_ExtendedModeUpdate() throws SQLException {
+    ((CloudSpannerConnection) getConnection()).setAllowExtendedMode(true);
+    try (ResultSet rs =
+        getConnection().createStatement().executeQuery("select * from test order by id")) {
+      int i = 0;
+      while (rs.next()) {
+        assertEquals(String.valueOf(i), rs.getString("name"));
+        i++;
+      }
+    }
+    PreparedStatement ps =
+        getConnection().prepareStatement("update test set name=concat('one', name) where id < ?");
+    ps.setLong(1, 10L);
+    ps.executeUpdate();
+    getConnection().commit();
+    try (ResultSet rs =
+        getConnection().createStatement().executeQuery("select * from test order by id")) {
+      int i = 0;
+      while (rs.next()) {
+        if (i < 10) {
+          assertEquals("one" + String.valueOf(i), rs.getString("name"));
+        } else {
+          assertEquals(String.valueOf(i), rs.getString("name"));
+        }
+        i++;
+      }
+    }
+  }
+
+  @Test
+  public void test2_ExtendedModeDelete() throws SQLException {
+    ((CloudSpannerConnection) getConnection()).setAllowExtendedMode(true);
+    try (ResultSet rs =
+        getConnection().createStatement().executeQuery("select count(*) from test where id<10")) {
+      while (rs.next()) {
+        assertEquals(10L, rs.getLong(1));
+      }
+    }
+    PreparedStatement ps = getConnection().prepareStatement("delete from test where id<?");
+    ps.setLong(1, 10L);
+    ps.executeUpdate();
+    getConnection().commit();
+    try (ResultSet rs =
+        getConnection().createStatement().executeQuery("select count(*) from test where id<10")) {
+      while (rs.next()) {
+        assertEquals(0L, rs.getLong(1));
+      }
+    }
+  }
+
+  @Test
+  public void test3_ExtendedModeDeleteWithId() throws SQLException {
+    ((CloudSpannerConnection) getConnection()).setAllowExtendedMode(true);
+    try (ResultSet rs = getConnection().createStatement()
+        .executeQuery("select count(*) from test where id=30 and name like '3%'")) {
+      while (rs.next()) {
+        assertEquals(1L, rs.getLong(1));
+      }
+    }
+    PreparedStatement ps =
+        getConnection().prepareStatement("delete from test where id=? and name like ?");
+    ps.setLong(1, 30L);
+    ps.setString(2, "3%");
+    ps.executeUpdate();
+    getConnection().commit();
+    try (ResultSet rs = getConnection().createStatement()
+        .executeQuery("select count(*) from test where id=30 and name like '3%'")) {
+      while (rs.next()) {
+        assertEquals(0L, rs.getLong(1));
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
When running in extended mode, the query that would determine whether the statement needed to be divided into multiple partitions would not include the actual parameter values that had been passed into the
original query.