### PR TITLE
#128 bypass sql parser when there are no parameters

### DIFF
--- a/src/test/java/nl/topicus/jdbc/statement/CloudSpannerPreparedStatementTest.java
+++ b/src/test/java/nl/topicus/jdbc/statement/CloudSpannerPreparedStatementTest.java
@@ -1092,7 +1092,7 @@ public class CloudSpannerPreparedStatementTest {
     public void testInvalidSQL() throws SQLException, MalformedURLException {
       thrown.expect(SQLException.class);
       thrown.expectMessage(CloudSpannerPreparedStatement.PARSE_ERROR);
-      String sql = "SELECT * FOO";
+      String sql = "SELECT * FOO WHERE some_param=?";
       CloudSpannerPreparedStatement ps = CloudSpannerTestObjects.createPreparedStatement(sql);
       try (ResultSet rs = ps.executeQuery()) {
       }
@@ -1249,10 +1249,10 @@ public class CloudSpannerPreparedStatementTest {
       try {
         Statement statement = CCJSqlParserUtil.parse(ps.sanitizeSQL(sql));
         Method createSelectBuilder = CloudSpannerPreparedStatement.class
-            .getDeclaredMethod("createSelectBuilder", Statement.class, String.class);
+            .getDeclaredMethod("createSelectBuilder", boolean.class, Statement.class, String.class);
         createSelectBuilder.setAccessible(true);
-        res = (com.google.cloud.spanner.Statement.Builder) createSelectBuilder.invoke(ps, statement,
-            sql);
+        res = (com.google.cloud.spanner.Statement.Builder) createSelectBuilder.invoke(ps, true,
+            statement, sql);
       } catch (NoSuchMethodException | SecurityException | IllegalAccessException
           | IllegalArgumentException | JSQLParserException e) {
         throw new RuntimeException(e);

--- a/src/test/java/nl/topicus/jdbc/test/integration/specific/SelectStatementsWithParametersIT.java
+++ b/src/test/java/nl/topicus/jdbc/test/integration/specific/SelectStatementsWithParametersIT.java
@@ -129,6 +129,13 @@ public class SelectStatementsWithParametersIT extends AbstractSpecificIntegratio
     testSqlStatement(sql, 1, false, params);
   }
 
+  @Test
+  public void testSelectArrayIndex() throws SQLException {
+    String sql =
+        "SELECT DISTINCT DOMAIN FROM (SELECT 'test' as DOMAIN, 4 as client_id, 42 as profile_id, array (select 1 union all select 2 union all select 3) as visits) foo WHERE client_id=4 AND profile_id=42 AND visits[0] > 0";
+    testSqlStatement(sql, 1, false);
+  }
+
   private void testSqlStatement(String sql) throws SQLException {
     testSqlStatement(sql, 1, true);
   }


### PR DESCRIPTION
The SQL parser should be bypassed when a SQL statement cannot be parsed, but there are no parameters that need to be filled in anyways.